### PR TITLE
bug concerning wrong price quotation

### DIFF
--- a/upload/catalog/model/extension/shipping/flagship.php
+++ b/upload/catalog/model/extension/shipping/flagship.php
@@ -192,13 +192,15 @@ class ModelExtensionShippingflagship extends Model {
         $imperialLengthClass = $this->getImperialLengthClass();
         $imperialWeightClass = $this->getImperialWeightClass();
         foreach ($products as $product) {
-            $items[] = [
-                "length" => $product["length"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["length"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["length"]) ),
-                "width" => $product["width"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["width"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["width"])),
-                "height" => $product["height"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["height"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["height"])),
-                "weight" => $product["weight"] < 1 ? 1 : ($product['weight_class_id'] != $imperialWeightClass ? $this->weight->convert($product["weight"],$product['weight_class_id'],$imperialWeightClass) : $product["weight"]),
-                "description" => $product["name"]
-            ];
+            for($i=0; $i < $product['quantity']; $i++){
+		$items[] = [
+			"length" => $product["length"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["length"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["length"]) ),
+			"width" => $product["width"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["width"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["width"])),
+			"height" => $product["height"] == 0 ? 1 : ($product['length_class_id'] != $imperialLengthClass ? ceil($this->length->convert($product["height"],$product['length_class_id'],$imperialLengthClass)) : ceil($product["height"])),
+			"weight" => $product["weight"] < 1 ? 1 : ($product['weight_class_id'] != $imperialWeightClass ? $this->weight->convert($product["weight"],$product['weight_class_id'],$imperialWeightClass) : $product["weight"]/$product['quantity']),
+			"description" => $product["name"]
+	    	];	
+            }	
         }
         return $items;
     }


### PR DESCRIPTION
when the same product is selected x times opencart returns just one item but with the combined quantities.
for example :
if a product X ( weight 1kg ) is chosen with a quantity of  5  
this part of the code 
$products = $this->cart->getProducts();
returns one item but with a total weight of 5kg
which results of a wrong price quotation because it will caculate just one item with a weight of 5kg
instead of 5 item with a weight of 1kg each
this is a fix for that