### PR TITLE
fix error handling

### DIFF
--- a/upload/catalog/model/extension/shipping/flagship.php
+++ b/upload/catalog/model/extension/shipping/flagship.php
@@ -106,8 +106,14 @@ class ModelExtensionShippingflagship extends Model
         ];
         curl_close($curl);
 
-        if (isset($responseArray['response']->errors)) {
-            $errors = implode(PHP_EOL, $responseArray['response']->errors);
+        if (isset($responseArray['response']->errors) and empty($responseArray['response']->content)) {
+            $errors = '';
+            foreach ($responseArray['response']->errors as $key => $error) {
+                foreach ($error as $message) {
+                    $errors .= PHP_EOL . $key . ' : ' . $message;
+                }
+            }
+
             return ['errors' => $errors];
         }
 


### PR DESCRIPTION
sometimes the api response returns rates and errors at the same time, if a carrier is not accepting the quote which results in the module returning an empty array instead of the valid rates quoted and ignoring the error.